### PR TITLE
feat: Repassados arquivos de injeção de dependência de infraestrutura…

### DIFF
--- a/Financeiro.Application/Financeiro.Application.csproj
+++ b/Financeiro.Application/Financeiro.Application.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Financeiro.Domain\Financeiro.Domain.csproj" />
-    <ProjectReference Include="..\Financeiro.Infrastructure\Financeiro.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Financeiro.ConsoleApp/Financeiro.ConsoleApp.csproj
+++ b/Financeiro.ConsoleApp/Financeiro.ConsoleApp.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Financeiro.Application\Financeiro.Application.csproj" />
     <ProjectReference Include="..\Financeiro.EfdReinf\Financeiro.EfdReinf.csproj" />
+    <ProjectReference Include="..\Financeiro.Infrastructure\Financeiro.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Financeiro.ConsoleApp/Program.cs
+++ b/Financeiro.ConsoleApp/Program.cs
@@ -1,30 +1,18 @@
 ﻿using Financeiro.Application.UseCases;
-using Financeiro.ConsoleApp;
 using Financeiro.Domain.Data.Interfaces;
 using Financeiro.Domain.EfdReinf.DTOs;
 using Financeiro.Domain.EfdReinf.Interfaces;
-using Financeiro.EfdReinf.WebServices;
 
 Console.WriteLine("O EFD Reinf possui 2 versões disponíveis para o envio dos XMLs. Selecione: ");
 Console.WriteLine("1 - Versão 1 (versão que será descontinuada em 10 dias);");
 Console.WriteLine($"2 - Versão 2 (versão obrigatória a partir de {DateTime.Now.AddDays(10).ToShortDateString()});");
 
-IDespesasRepository despesasRepository = ContainerDependencyInjection.DespesasRepository;
+IDespesasRepository despesasRepository = Financeiro.Infrastructure.ContainerDependencyInjection.DespesasRepository;
 string? selectedEfdReinfVersion = Console.ReadLine();
-IEfdReinf efdReinf = GetEfdReinf(selectedEfdReinfVersion);
+IEfdReinf efdReinf = Financeiro.EfdReinf.ContainerDependencyInjection.GetEfdReinf(selectedEfdReinfVersion);
 EnviarR2020 enviarR2020 = new(despesasRepository, efdReinf);
 
 EnviarR2020Requisicao requisicao = new(02, 2023);
 EnviarR2020Resposta respostaEfdReinf = await enviarR2020.ExecuteAsync(requisicao);
 
 Console.WriteLine($"\r\nResultado da ação: {respostaEfdReinf.StatusResposta}");
-
-static IEfdReinf GetEfdReinf(string? selectedEfdReinfVersion)
-{
-    return selectedEfdReinfVersion switch
-    {
-        "1" => new EfdReinfV1(),
-        "2" => new EfdReinfV2(),
-        _ => throw new ArgumentOutOfRangeException(selectedEfdReinfVersion, $"Versão selecionada inválida: '{selectedEfdReinfVersion}'")
-    };
-}

--- a/Financeiro.EfdReinf/ContainerDependencyInjection.cs
+++ b/Financeiro.EfdReinf/ContainerDependencyInjection.cs
@@ -1,0 +1,16 @@
+﻿using Financeiro.Domain.EfdReinf.Interfaces;
+using Financeiro.EfdReinf.WebServices;
+
+namespace Financeiro.EfdReinf;
+public static class ContainerDependencyInjection
+{
+    public static IEfdReinf GetEfdReinf(string? selectedEfdReinfVersion)
+    {
+        return selectedEfdReinfVersion switch
+        {
+            "1" => new EfdReinfV1(),
+            "2" => new EfdReinfV2(),
+            _ => throw new ArgumentOutOfRangeException(selectedEfdReinfVersion, $"Versão selecionada inválida: '{selectedEfdReinfVersion}'")
+        };
+    }
+}

--- a/Financeiro.Infrastructure/ContainerDependencyInjection.cs
+++ b/Financeiro.Infrastructure/ContainerDependencyInjection.cs
@@ -1,7 +1,7 @@
 ﻿using Financeiro.Domain.Data.Interfaces;
 using Financeiro.Infrastructure.Data;
 
-namespace Financeiro.ConsoleApp;
+namespace Financeiro.Infrastructure;
 public static class ContainerDependencyInjection
 {
     public static IDespesasRepository DespesasRepository => new DespesasRepositoryMemory();


### PR DESCRIPTION
… e EfdReinf para seus devidos projetos

- Isso não torna a inversão de controle fixa, é apenas a inversão de controle padrão (nada impede que cada agente de interação com a aplicação - seja ConsoleApp, API, Tests - façam a inversão de controle conforme desejarem);
- No projeto de aplicação, retirada referência do projeto de infraestrutura, e repassada para projeto 'ConsoleApp';